### PR TITLE
GraphQL user email mutation tests

### DIFF
--- a/database/seeds/006-userEmails.js
+++ b/database/seeds/006-userEmails.js
@@ -1,0 +1,32 @@
+exports.seed = function seedUsers(knex) {
+  return knex('userEmails')
+    .del()
+    .then(() =>
+      knex('userEmails').insert([
+        {
+          // id: 1,
+          email: 'trufflin.waffles@gmail.com',
+          userId: 1,
+          valid: true
+        },
+        {
+          // id: 2,
+          email: 'cool_skool@educ.com',
+          userId: 3,
+          valid: false
+        },
+        {
+          // id: 3,
+          email: 'learners.learn@study.edu',
+          userId: 3,
+          valid: true
+        },
+        {
+          // id: 4,
+          email: 'studley@lulz.net',
+          userId: 8,
+          valid: false
+        }
+      ])
+    );
+};


### PR DESCRIPTION
# Description

Various tests for GraphQL mutations involving user email information:
• `addUserEmail`
• `deleteUserEmail`

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works AND the tests pass