### PR TITLE
Bugfix/user mutation args id to number

### DIFF
--- a/schema/mutations/userMutations.js
+++ b/schema/mutations/userMutations.js
@@ -155,7 +155,7 @@ module.exports = {
       }
     },
     resolve(parent, args, ctx) {
-      if (Number(ctx.roleId) !== 1 && ctx.userId !== args.userId)
+      if (Number(ctx.roleId) !== 1 && ctx.userId !== Number(args.userId))
         return new Error('Unauthorized');
       let fullName = '';
       Student.findByUserId(args.userId)

--- a/schema/mutations/userMutations.js
+++ b/schema/mutations/userMutations.js
@@ -120,7 +120,7 @@ module.exports = {
       }
     },
     resolve(parent, args, ctx) {
-      if (Number(ctx.roleId) !== 1 && ctx.userId !== args.id)
+      if (Number(ctx.roleId) !== 1 && ctx.userId !== Number(args.id))
         return new Error('Unauthorized');
 
       return User.remove(args.id)


### PR DESCRIPTION
# Description

`addUserEmail` & `deleteUser`

`args.userId` was returning a` string` instead of a `number`

```
if (Number(ctx.roleId) !== 1 && ctx.userId !== Number(args.userId))
        return new Error('Unauthorized');
```

## Checklist

- [x] I have performed a self-review of my own code